### PR TITLE
Search for main branch name was missing short-circuit return

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,3 +1,4 @@
+
 [//]: # (vim: spell)
 
 # Frequently asked questions

--- a/Makefile
+++ b/Makefile
@@ -10,20 +10,20 @@
 #
 #	-- Last letter:
 #	'm' refers to main/master branch
-#	'f' refers to feature (dev) branch
+#	'f' refers to feature (work) branch
 #
 # Examples:
-# 	dm == dlm == diff local master
+# 	dm == dlm == diff local main
 # 	drf == dof == diff remote (origin) feature branch
 #
 MB = main
-FB = dev
+FB = work
 
 all: 3way-sync		#-- top level make target
 
 .PHONY: help dm dm dof drf dom drm help s3 3way-sync
 
-dm dlm:			#-- git diff vs local master
+dm dlm:			#-- git diff vs local main
 	#
 	# check that our $(FB) branch is identical to $(MB)
 	#
@@ -35,7 +35,7 @@ dof drf:		#-- git diff vs remote (origin) feature branch
 	#
 	git diff remotes/origin/$(FB)
 
-dom drm:		#-- git diff vs remote (origin) master
+dom drm:		#-- git diff vs remote (origin) main
 	#
 	# check that our $(FB) branch is identical to the _remote_ $(MB)
 	#
@@ -53,7 +53,7 @@ dom drm:		#-- git diff vs remote (origin) master
 sof srf:		#-- push to remote (origin) feaure branch
 	git push -f
 
-slm sm:			#-- pull in local master
+slm sm:			#-- pull in local main
 	#
 	# Get latest into local $(MB)
 	#

--- a/clean-push
+++ b/clean-push
@@ -21,8 +21,10 @@
 #
 # Author: Ariel Faigon, 2021
 #
+PROG="$(basename "$0")"
+
 function out() {
-    echo "$0: $@"
+    echo "$PROG: $@"
 }
 
 function err() {
@@ -131,19 +133,22 @@ function has-parent-process-named() {
 }
 
 function local-branch-exists() {
-    local branchname="$1"
-    git show-ref --verify --quiet "refs/heads/$branchname"
-    # $? == 0 means local branch <branchname> exists.
+    local branch="$1"
+    git show-ref --verify --quiet "refs/heads/$branch"
+    # $? == 0 means local branch <branch> exists.
 }
 
 function get-main-branch-name() {
     local arg="$1"
-    for branch in "$arg" 'master' 'main'; do
+    for branch in "$arg" 'dev' 'staging' 'main' 'master'; do
         if [[ -z "$branch" ]]; then
             continue
         fi
+        err "get-main-branch-name: trying branch: $branch ..."
         if local-branch-exists "$branch"; then
+            # err "get-main-branch-name: local-branch $branch FOUND"
             echo "$branch"
+            return
         fi
     done
 }


### PR DESCRIPTION
    - Add 'dev', 'staging' to search options for main branch
    - Add 'dev' to list of main branches; make 'work' the topic branch
    - Fix docs to be consistent
    - Nicer outputs via PROG="$(basename "$0")"
    - Makefile: branch naming consistent with docs