### PR TITLE
Revert failed attempt at auto parent-branch detection

### DIFF
--- a/4-way-diff
+++ b/4-way-diff
@@ -39,7 +39,7 @@ function current-branch() {
     git rev-parse --abbrev-ref HEAD
 }
 
-function parent-branch() {
+function reflog-last-checkout() {
     local CB="$(current-branch)"
     git reflog |
         grep -Eo ": moving from .* to $CB\$" |
@@ -63,9 +63,9 @@ function local-branch-exists() {
 
 function get-main-branch-name() {
     local arg="$1"
-    local pb="$(parent-branch)"
+    local lc="$(reflog-last-checkout)"
 
-    for branch in "$arg" "$pb" 'dev' 'staging' 'main' 'master'; do
+    for branch in "$arg" "$pb" 'dev' 'staging' 'main' 'master' "$lc"; do
         if [[ -z "$branch" ]]; then
             continue
         fi

--- a/clean-push
+++ b/clean-push
@@ -43,7 +43,7 @@ function current-branch() {
     git rev-parse --abbrev-ref HEAD
 }
 
-function parent-branch() {
+function reflog-last-checkout() {
     local CB="$(current-branch)"
     git reflog |
         grep -Eo ": moving from .* to $CB\$" |
@@ -164,9 +164,9 @@ function local-branch-exists() {
 
 function get-main-branch-name() {
     local arg="$1"
-    local pb="$(parent-branch)"
+    local lc="$(reflog-last-checkout)"
 
-    for branch in "$arg" "$pb" 'dev' 'staging' 'main' 'master'; do
+    for branch in "$arg" 'dev' 'staging' 'main' 'master' "$lc"; do
         if [[ -z "$branch" ]]; then
             continue
         fi


### PR DESCRIPTION
- Rename 'parent-branch' to reflog-last-checkout'
- Use reflog-last-checkout result only as last resort